### PR TITLE
Unnecessary setTimeout() function

### DIFF
--- a/easy_background.js
+++ b/easy_background.js
@@ -87,11 +87,7 @@ function easy_background(selector, sld_args) {
         //collect delay first time
         li = sld_args.delay[iii];
 
-        setTimeout(function() {
-
-          document.querySelector(selector).style.backgroundImage = "url('" + vvv + "')";
-
-        }, 0000); // 1
+        document.querySelector(selector).style.backgroundImage = "url('" + vvv + "')";
 
       }
 


### PR DESCRIPTION
This setTimeout function has the milliseconds set to 0000 and is therefore unnecessary. I had to remove this as my linter complained that 0000 is not a valid value and the JS build therefore failed.